### PR TITLE
TensorUDT prototype point commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ tour/*.tiff
 scoverage-report*
 
 zz-*
+venv

--- a/core/src/main/scala/geotrellis/raster/ArrowTensor.scala
+++ b/core/src/main/scala/geotrellis/raster/ArrowTensor.scala
@@ -1,0 +1,116 @@
+package geotrellis.raster
+
+import java.io.{ByteArrayInputStream, FileInputStream}
+import java.nio.ByteBuffer
+import java.nio.channels.Channels
+
+import com.google.flatbuffers.FlatBufferBuilder
+import org.apache.arrow.flatbuf.{Buffer, Tensor, TensorDim, Type}
+import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.vector.ipc.ReadChannel
+import org.apache.arrow.vector.ipc.message.{ArrowFieldNode, MessageSerializer}
+import org.apache.arrow.vector.types.FloatingPointPrecision
+import org.apache.arrow.vector.types.pojo.{ArrowType, Field, FieldType, Schema}
+import org.apache.arrow.vector.{Float8Vector, VectorSchemaRoot}
+
+import scala.collection.JavaConverters._
+
+class ArrowTensor(vector: Float8Vector, shape: Seq[Int]) {
+
+  /** Write Tensor to buffer, return offset of Tensor object in that buffer */
+  def writeTensor(bufferBuilder: FlatBufferBuilder): Int = {
+    val elementSize = 8
+
+    // TODO: make work for more than 2 dimensions
+    // Array[Long](shape(0) * elementSize, elementSize)
+    val strides: Array[Long] = {
+      shape.rev
+    }
+
+    val shapeOffset: Int = {
+      val rank = shape.length
+      val tensorDimOffsets = new Array[Int](rank)
+      val nameOffset = new Array[Int](rank)
+
+      for (i <- shape.indices) {
+        nameOffset(i) = bufferBuilder.createString("")
+        tensorDimOffsets(i) = TensorDim.createTensorDim(bufferBuilder, shape(i), nameOffset(i))
+      }
+
+      Tensor.createShapeVector(bufferBuilder, tensorDimOffsets)
+    }
+
+    val typeOffset = org.apache.arrow.flatbuf.Int.createInt(bufferBuilder, 32,true)
+
+    val stridesOffset = Tensor.createStridesVector(bufferBuilder, strides)
+    Tensor.startTensor(bufferBuilder)
+    Tensor.addTypeType(bufferBuilder, Type.Int)
+    // pa.read_tensor also wants type, ND4j does not write this because it I'm guessing its not written to python
+    Tensor.addType(bufferBuilder, typeOffset)
+    Tensor.addShape(bufferBuilder, shapeOffset)
+    Tensor.addStrides(bufferBuilder, stridesOffset)
+    // Buffers offset is relative to memory page, not the IPC message.
+    val tensorBodyOffset: Int = 0
+    val tensorBodySize: Int = vector.getValueCount * 8
+    val dataOffset = Buffer.createBuffer(bufferBuilder, tensorBodyOffset, tensorBodySize)
+    Tensor.addData(bufferBuilder, dataOffset)
+    Tensor.endTensor(bufferBuilder)
+  }
+
+  def toIpcMessage(): ByteBuffer = {
+    val bufferBuilder = new FlatBufferBuilder(512)
+    val tensorOffset = writeTensor(bufferBuilder)
+    val tensorBodySize: Int = vector.getValueCount * 8
+    MessageSerializer.serializeMessage(bufferBuilder, org.apache.arrow.flatbuf.MessageHeader.Tensor, tensorOffset, tensorBodySize);
+  }
+}
+
+object ArrowTensor {
+  val schema: Schema = {
+    val fieldArr = new Field(
+      "array",
+      new FieldType(false, new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE), null, null),
+      Nil.asJava)
+
+    new Schema(List(fieldArr).asJava)
+  }
+
+  def fromArray(arr: Array[Double], shape: Int*): ArrowTensor = {
+    val allocator = new RootAllocator(Long.MaxValue)
+    val root = VectorSchemaRoot.create(schema, allocator)
+    val vec = new Float8Vector("array", allocator)
+    vec.allocateNew(arr.length)
+    for (i <- arr.indices) vec.set(i, arr(i))
+    vec.setValueCount(arr.length)
+    root.setRowCount(arr.length)
+    new ArrowTensor(vec, shape.toArray)
+  }
+
+  def fromArrowMessage(bytes: Array[Byte]): ArrowTensor = {
+    val allocator = new RootAllocator(Integer.MAX_VALUE)
+    val is = new ByteArrayInputStream(bytes)
+    val channel = Channels.newChannel(is)
+    val readChannel = new ReadChannel(channel)
+    val msg = MessageSerializer.readMessage(readChannel)
+
+    // TODO: use tensor information to build the right kind of tensor
+    val tensor = new Tensor()
+    msg.getMessage.header(tensor)
+
+    val arrowBuf = MessageSerializer.readMessageBody(readChannel, msg.getMessageBodyLength.toInt, allocator)
+
+    val root = VectorSchemaRoot.create(schema, allocator)
+    val vec = new Float8Vector("array", allocator)
+    def shape = {
+      for (i <- 0 until tensor.shapeLength()) yield tensor.shape(i).size().toInt
+    }.toArray
+
+    val tensorSize = shape.product
+
+    vec.setValueCount(tensorSize)
+    // TODO: find a way to reference this buffer directly, this is obviously horrible
+    for (i <- 0 until tensorSize) vec.set(i, Float8Vector.get(arrowBuf, i))
+
+    new ArrowTensor(vec, shape)
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/rf/TensorUDT.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rf/TensorUDT.scala
@@ -1,0 +1,90 @@
+/*
+ * This software is licensed under the Apache 2 license, quoted below.
+ *
+ * Copyright 2018 Azavea, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     [http://www.apache.org/licenses/LICENSE-2.0]
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.apache.spark.sql.rf
+import geotrellis.raster._
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.types.{DataType, _}
+import org.locationtech.rasterframes.encoders.CatalystSerializer
+import org.locationtech.rasterframes.encoders.CatalystSerializer._
+import org.locationtech.rasterframes.model.{Cells, TileDataContext}
+import org.locationtech.rasterframes.ref.RasterRef.RasterRefTile
+import org.locationtech.rasterframes.tiles.InternalRowTile
+
+
+/**
+  * UDT for singleband tiles.
+  *
+  * @since 11/18/19
+  */
+@SQLUserDefinedType(udt = classOf[TensorUDT])
+class TensorUDT extends UserDefinedType[ArrowTensor] {
+  import TensorUDT._
+  override def typeName = TensorUDT.typeName
+
+  override def pyUDT: String = "pyrasterframes.rf_types.TensorUDT"
+
+  def userClass: Class[ArrowTensor] = classOf[ArrowTensor]
+
+  def sqlType: StructType = schemaOf[ArrowTensor]
+
+  override def serialize(obj: ArrowTensor): InternalRow =
+    Option(obj)
+      .map(_.toInternalRow)
+      .orNull
+
+  override def deserialize(datum: Any): ArrowTensor =
+    Option(datum)
+      .collect {
+        case ir: InternalRow ⇒ ir.to[ArrowTensor]
+      }
+      .orNull
+
+  override def acceptsType(dataType: DataType): Boolean = dataType match {
+    case _: TensorUDT ⇒ true
+    case _ ⇒ super.acceptsType(dataType)
+  }
+}
+
+case object TensorUDT  {
+  UDTRegistration.register(classOf[ArrowTensor].getName, classOf[TensorUDT].getName)
+
+  final val typeName: String = "tensor"
+
+  implicit def tensorSerializer: CatalystSerializer[ArrowTensor] = new CatalystSerializer[ArrowTensor] {
+
+    override val schema: StructType = StructType(Seq(
+      StructField("arrow_tensor", BinaryType, true)
+    ))
+
+    override def to[R](t: ArrowTensor, io: CatalystIO[R]): R = io.create(
+      // TODO: encode ArrowTensor into bytes and Byte array here
+      Array.empty[Byte]
+    )
+
+    override def from[R](row: R, io: CatalystIO[R]): ArrowTensor = {
+      val bytes = io.getByteArray(row, 0)
+      ArrowTensor.fromArrowMessage(bytes)
+      // TODO: decode the arrow buffer here
+      ???
+    }
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/rf/package.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rf/package.scala
@@ -43,6 +43,7 @@ package object rf {
     // which is where the registration actually happens. The ordering matters!
     RasterSourceUDT
     TileUDT
+    TensorUDT
   }
 
   def registry(sqlContext: SQLContext): FunctionRegistry = {

--- a/core/src/main/scala/org/locationtech/rasterframes/StandardColumns.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/StandardColumns.scala
@@ -24,7 +24,7 @@ package org.locationtech.rasterframes
 import java.sql.Timestamp
 
 import geotrellis.proj4.CRS
-import geotrellis.raster.Tile
+import geotrellis.raster.{ArrowTensor, Tile}
 import geotrellis.spark.{SpatialKey, TemporalKey}
 import geotrellis.vector.{Extent, ProjectedExtent}
 import org.apache.spark.sql.functions.col
@@ -70,6 +70,10 @@ trait StandardColumns {
   /** Default RasterFrameLayer tile column name. */
   // This is a `def` because `TileUDT` needs to be initialized first.
   def TILE_COLUMN = col("tile").as[Tile]
+  /** Default RasterFrameLayer tile column name. */
+
+  // This is a `def` because `TileUDT` needs to be initialized first.
+  def TENSOR_COLUMN = col("tensor").as[ArrowTensor]
 
   /** Default column name for a tile with its CRS and Extent. */
   def PROJECTED_RASTER_COLUMN = col("proj_raster").as[ProjectedRasterTile]

--- a/core/src/main/scala/org/locationtech/rasterframes/encoders/StandardEncoders.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/encoders/StandardEncoders.scala
@@ -27,7 +27,7 @@ import java.sql.Timestamp
 import org.locationtech.rasterframes.stats.{CellHistogram, CellStatistics, LocalCellStatistics}
 import org.locationtech.jts.geom.Envelope
 import geotrellis.proj4.CRS
-import geotrellis.raster.{CellSize, CellType, Raster, Tile, TileLayout}
+import geotrellis.raster.{ArrowTensor, CellSize, CellType, Raster, Tile, TileLayout}
 import geotrellis.spark.tiling.LayoutDefinition
 import geotrellis.spark.{KeyBounds, SpaceTimeKey, SpatialKey, TemporalKey, TemporalProjectedExtent, TileLayerMetadata}
 import geotrellis.vector.{Extent, ProjectedExtent}
@@ -71,8 +71,7 @@ trait StandardEncoders extends SpatialEncoders {
   implicit def tileContextEncoder: ExpressionEncoder[TileContext] = TileContext.encoder
   implicit def tileDataContextEncoder: ExpressionEncoder[TileDataContext] = TileDataContext.encoder
   implicit def extentTilePairEncoder: Encoder[(ProjectedExtent, Tile)] = Encoders.tuple(projectedExtentEncoder, singlebandTileEncoder)
-
-
+  implicit def tensorEncoder: ExpressionEncoder[ArrowTensor] = ExpressionEncoder()
 }
 
 object StandardEncoders extends StandardEncoders

--- a/core/src/main/scala/org/locationtech/rasterframes/rasterframes.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/rasterframes.scala
@@ -25,7 +25,7 @@ import com.typesafe.scalalogging.Logger
 import geotrellis.raster.{Tile, TileFeature, isData}
 import geotrellis.spark.{ContextRDD, Metadata, SpaceTimeKey, SpatialKey, TileLayerMetadata}
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.rf.{RasterSourceUDT, TileUDT}
+import org.apache.spark.sql.rf.{RasterSourceUDT, TensorUDT, TileUDT}
 import org.apache.spark.sql.{DataFrame, SQLContext, rf}
 import org.locationtech.geomesa.spark.jts.DataFrameFunctions
 import org.locationtech.rasterframes.encoders.StandardEncoders
@@ -85,6 +85,9 @@ package object rasterframes extends StandardColumns
 
   /** TileUDT type reference. */
   def TileType = new TileUDT()
+
+  /** TensorUDT type reference. */
+  def TensorType = new TensorUDT()
 
   /** RasterSourceUDT type reference. */
   def RasterSourceType = new RasterSourceUDT()

--- a/core/src/test/scala/org/locationtech/rasterframes/TensorUDTSpec.scala
+++ b/core/src/test/scala/org/locationtech/rasterframes/TensorUDTSpec.scala
@@ -1,0 +1,98 @@
+/*
+ * This software is licensed under the Apache 2 license, quoted below.
+ *
+ * Copyright 2017 Azavea, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     [http://www.apache.org/licenses/LICENSE-2.0]
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.locationtech.rasterframes
+import geotrellis.raster.{ArrowTensor, CellType, NoNoData, Tile}
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
+import org.apache.spark.sql.rf._
+import org.locationtech.rasterframes.encoders.CatalystSerializer._
+import org.scalatest.Inspectors
+
+/**
+  * RasterFrameLayer test rig.
+  *
+  * @since 11/18/2019
+  */
+class TensorUDTSpec extends TestEnvironment with TestData with Inspectors {
+
+  spark.version
+  val tensorEncoder: ExpressionEncoder[ArrowTensor] = ExpressionEncoder()
+  implicit val ser = TensorUDT.tensorSerializer
+
+  describe("TensorUDT") {
+    val tileSizes = Seq(2, 7, 64, 128, 511)
+    val ct = functions.cellTypes().filter(_ != "bool")
+
+//    it("should (de)serialize tile") {
+//      val tensor: ArrowTensor = ArrowTensor.fromArray(
+//        Array[Double](1,2,3,4), 2,2)
+//      val row = TensorType.serialize(tensor)
+//      val tensorAgain = TileType.deserialize(row)
+//      assert(tensorAgain === tensor)
+//    }
+//
+    it("should (en/de)code tile") {
+      val tensor: ArrowTensor = ArrowTensor.fromArray(
+        Array[Double](1,2,3,4), 2,2)
+      val row = tensorEncoder.toRow(tensor)
+      assert(!row.isNullAt(0))
+      val tileAgain = TensorType.deserialize(row.getStruct(0, TensorType.sqlType.size))
+      assert(tileAgain === tensor)
+    }
+//
+//    it("should extract properties") {
+//      forEveryConfig { tile ⇒
+//        val row = TileType.serialize(tile)
+//        val wrapper = row.to[Tile]
+//        assert(wrapper.cols === tile.cols)
+//        assert(wrapper.rows === tile.rows)
+//        assert(wrapper.cellType === tile.cellType)
+//      }
+//    }
+//
+//    it("should directly extract cells") {
+//      forEveryConfig { tile ⇒
+//        val row = TileType.serialize(tile)
+//        val wrapper = row.to[Tile]
+//        val (cols,rows) = wrapper.dimensions
+//        val indexes = Seq((0, 0), (cols - 1, rows - 1), (cols/2, rows/2), (1, 1))
+//        forAll(indexes) { case (c, r) ⇒
+//          assert(wrapper.get(c, r) === tile.get(c, r))
+//          assert(wrapper.getDouble(c, r) === tile.getDouble(c, r))
+//        }
+//      }
+//    }
+//
+//    it("should provide a pretty-print tile") {
+//      import spark.implicits._
+//      forEveryConfig { tile =>
+//        val stringified = Seq(tile).toDF("tile").select($"tile".cast(StringType)).as[String].first()
+//        stringified should be(ShowableTile.show(tile))
+//
+//        if(!tile.cellType.isInstanceOf[NoNoData]) {
+//          val withNd = tile.mutable
+//          withNd.update(0, raster.NODATA)
+//          ShowableTile.show(withNd) should include("--")
+//        }
+//      }
+//    }
+  }
+}

--- a/pyrasterframes/src/main/python/tests/PyRasterFramesTests.py
+++ b/pyrasterframes/src/main/python/tests/PyRasterFramesTests.py
@@ -244,6 +244,16 @@ class UDT(TestEnvironment):
         self.assertTrue(np.all(r1.cells == exp_array))
         self.assertEqual(r1.cells.dtype, exp_array.dtype)
 
+    def test_pandas_udf(self):
+        from pyspark.sql.functions import pandas_udf, PandasUDFType
+
+        @pandas_udf('double', PandasUDFType.SCALAR)
+        def tile_mean(cells):
+            # `cells` is a Pandas `Series`.
+            return cells.apply(np.mean)
+
+        df = self.rf.select(tile_mean(self.rf.tile).alias('pandas_udf_mean'))
+        df.show(truncate=False)
 
 class TileOps(TestEnvironment):
 

--- a/pyrasterframes/src/main/python/tests/__init__.py
+++ b/pyrasterframes/src/main/python/tests/__init__.py
@@ -42,7 +42,7 @@ def resource_dir():
     rez_dir = os.path.realpath(os.path.join(scala_target, 'test-classes'))
     # If not running in build mode, try source dirs.
     if not os.path.exists(rez_dir):
-        rez_dir = os.path.realpath(os.path.join(pdir(pdir(pdir(here))), 'test', 'resources'))
+        rez_dir = os.path.realpath(os.path.join(pdir(pdir(pdir(here))), 'src', 'test', 'resources'))
     return rez_dir
 
 


### PR DESCRIPTION
Prototype to use Arrow Tensor IPC message to add a tensor UDT.

The aim are twofold:
- Add a tensor UDT which is the main objective for our target workflows
- Use some kind of arrow encoding in hopes that it can be improved on

Its worth noting that in current world the bytes will still passed through python pickler on the way to python executors, which can't be great for performance. 