### PR TITLE
TensorUDT prototype point commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ tour/*.tiff
 scoverage-report*
 
 zz-*
+venv

--- a/core/src/main/scala/geotrellis/raster/ArrowTensor.scala
+++ b/core/src/main/scala/geotrellis/raster/ArrowTensor.scala
@@ -1,0 +1,116 @@
+package geotrellis.raster
+
+import java.io.{ByteArrayInputStream, FileInputStream}
+import java.nio.ByteBuffer
+import java.nio.channels.Channels
+
+import com.google.flatbuffers.FlatBufferBuilder
+import org.apache.arrow.flatbuf.{Buffer, Tensor, TensorDim, Type}
+import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.vector.ipc.ReadChannel
+import org.apache.arrow.vector.ipc.message.{ArrowFieldNode, MessageSerializer}
+import org.apache.arrow.vector.types.FloatingPointPrecision
+import org.apache.arrow.vector.types.pojo.{ArrowType, Field, FieldType, Schema}
+import org.apache.arrow.vector.{Float8Vector, VectorSchemaRoot}
+
+import scala.collection.JavaConverters._
+
+class ArrowTensor(vector: Float8Vector, shape: Seq[Int]) {
+
+  /** Write Tensor to buffer, return offset of Tensor object in that buffer */
+  def writeTensor(bufferBuilder: FlatBufferBuilder): Int = {
+    val elementSize = 8
+
+    // TODO: make work for more than 2 dimensions
+    // Array[Long](shape(0) * elementSize, elementSize)
+    val strides: Array[Long] = {
+      shape.rev
+    }
+
+    val shapeOffset: Int = {
+      val rank = shape.length
+      val tensorDimOffsets = new Array[Int](rank)
+      val nameOffset = new Array[Int](rank)
+
+      for (i <- shape.indices) {
+        nameOffset(i) = bufferBuilder.createString("")
+        tensorDimOffsets(i) = TensorDim.createTensorDim(bufferBuilder, shape(i), nameOffset(i))
+      }
+
+      Tensor.createShapeVector(bufferBuilder, tensorDimOffsets)
+    }
+
+    val typeOffset = org.apache.arrow.flatbuf.Int.createInt(bufferBuilder, 32,true)
+
+    val stridesOffset = Tensor.createStridesVector(bufferBuilder, strides)
+    Tensor.startTensor(bufferBuilder)
+    Tensor.addTypeType(bufferBuilder, Type.Int)
+    // pa.read_tensor also wants type, ND4j does not write this because it I'm guessing its not written to python
+    Tensor.addType(bufferBuilder, typeOffset)
+    Tensor.addShape(bufferBuilder, shapeOffset)
+    Tensor.addStrides(bufferBuilder, stridesOffset)
+    // Buffers offset is relative to memory page, not the IPC message.
+    val tensorBodyOffset: Int = 0
+    val tensorBodySize: Int = vector.getValueCount * 8
+    val dataOffset = Buffer.createBuffer(bufferBuilder, tensorBodyOffset, tensorBodySize)
+    Tensor.addData(bufferBuilder, dataOffset)
+    Tensor.endTensor(bufferBuilder)
+  }
+
+  def toIpcMessage(): ByteBuffer = {
+    val bufferBuilder = new FlatBufferBuilder(512)
+    val tensorOffset = writeTensor(bufferBuilder)
+    val tensorBodySize: Int = vector.getValueCount * 8
+    MessageSerializer.serializeMessage(bufferBuilder, org.apache.arrow.flatbuf.MessageHeader.Tensor, tensorOffset, tensorBodySize);
+  }
+}
+
+object ArrowTensor {
+  val schema: Schema = {
+    val fieldArr = new Field(
+      "array",
+      new FieldType(false, new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE), null, null),
+      Nil.asJava)
+
+    new Schema(List(fieldArr).asJava)
+  }
+
+  def fromArray(arr: Array[Double], shape: Int*): ArrowTensor = {
+    val allocator = new RootAllocator(Long.MaxValue)
+    val root = VectorSchemaRoot.create(schema, allocator)
+    val vec = new Float8Vector("array", allocator)
+    vec.allocateNew(arr.length)
+    for (i <- arr.indices) vec.set(i, arr(i))
+    vec.setValueCount(arr.length)
+    root.setRowCount(arr.length)
+    new ArrowTensor(vec, shape.toArray)
+  }
+
+  def fromArrowMessage(bytes: Array[Byte]): ArrowTensor = {
+    val allocator = new RootAllocator(Integer.MAX_VALUE)
+    val is = new ByteArrayInputStream(bytes)
+    val channel = Channels.newChannel(is)
+    val readChannel = new ReadChannel(channel)
+    val msg = MessageSerializer.readMessage(readChannel)
+
+    // TODO: use tensor information to build the right kind of tensor
+    val tensor = new Tensor()
+    msg.getMessage.header(tensor)
+
+    val arrowBuf = MessageSerializer.readMessageBody(readChannel, msg.getMessageBodyLength.toInt, allocator)
+
+    val root = VectorSchemaRoot.create(schema, allocator)
+    val vec = new Float8Vector("array", allocator)
+    def shape = {
+      for (i <- 0 until tensor.shapeLength()) yield tensor.shape(i).size().toInt
+    }.toArray
+
+    val tensorSize = shape.product
+
+    vec.setValueCount(tensorSize)
+    // TODO: find a way to reference this buffer directly, this is obviously horrible
+    for (i <- 0 until tensorSize) vec.set(i, Float8Vector.get(arrowBuf, i))
+
+    new ArrowTensor(vec, shape)
+  }
+}

--- a/core/src/main/scala/geotrellis/raster/ArrowTensor.scala
+++ b/core/src/main/scala/geotrellis/raster/ArrowTensor.scala
@@ -1,6 +1,6 @@
 package geotrellis.raster
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream, FileInputStream}
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 import java.nio.ByteBuffer
 import java.nio.channels.Channels
 
@@ -8,7 +8,7 @@ import com.google.flatbuffers.FlatBufferBuilder
 import org.apache.arrow.flatbuf.{Buffer, Tensor, TensorDim, Type}
 import org.apache.arrow.memory.RootAllocator
 import org.apache.arrow.vector.ipc.{ReadChannel, WriteChannel}
-import org.apache.arrow.vector.ipc.message.{ArrowFieldNode, MessageSerializer}
+import org.apache.arrow.vector.ipc.message.MessageSerializer
 import org.apache.arrow.vector.types.FloatingPointPrecision
 import org.apache.arrow.vector.types.pojo.{ArrowType, Field, FieldType, Schema}
 import org.apache.arrow.vector.{Float8Vector, VectorSchemaRoot}
@@ -106,7 +106,7 @@ object ArrowTensor {
     val channel = Channels.newChannel(is)
     val readChannel = new ReadChannel(channel)
     val msg = MessageSerializer.readMessage(readChannel)
-    println("msg BB: " + msg.getMessageBuffer)
+    //println("msg BB: " + msg.getMessageBuffer)
 
     // TODO: use tensor information to build the right kind of tensor
     val tensor = new Tensor()

--- a/core/src/main/scala/geotrellis/raster/ArrowTensor.scala
+++ b/core/src/main/scala/geotrellis/raster/ArrowTensor.scala
@@ -6,12 +6,13 @@ import java.nio.channels.Channels
 
 import com.google.flatbuffers.FlatBufferBuilder
 import org.apache.arrow.flatbuf.{Buffer, Tensor, TensorDim, Type}
-import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.memory.{BufferAllocator, RootAllocator}
 import org.apache.arrow.vector.ipc.{ReadChannel, WriteChannel}
 import org.apache.arrow.vector.ipc.message.MessageSerializer
 import org.apache.arrow.vector.types.FloatingPointPrecision
 import org.apache.arrow.vector.types.pojo.{ArrowType, Field, FieldType, Schema}
 import org.apache.arrow.vector.{Float8Vector, VectorSchemaRoot}
+import spire.syntax.cfor._
 
 import scala.collection.JavaConverters._
 
@@ -20,6 +21,46 @@ case class ArrowTensor(val vector: Float8Vector, val shape: Seq[Int]) extends Ce
   def rows = shape(1)
   def cols = shape(2)
   val cellType = DoubleCellType
+
+  // TODO: Figure out how to work this crazy thing
+  // def copy(implicit alloc: BufferAllocator) = {
+  //   val n = vector.getValueCount
+  //   val copied = new Float8Vector("array", alloc)
+  //   val tp = vector.makeTransferPair(copied)
+  //   tp.copyValueSafe(0, n)
+  //   copied.copyFromSafe(0, n, vector)
+  //   copied.setValueCount(n)
+  //   ArrowTensor(copied, shape)
+  // }
+
+  def map(fn: Double => Double): ArrowTensor = {
+    val n = vector.getValueCount
+    val result = new Float8Vector("array", ArrowTensor.allocator)
+    result.allocateNew(n)
+    result.setValueCount(n)
+    cfor(0)(_ < n, _ + 1) { i =>
+      if (vector.isSet(i) == 1)
+        result.set(i, fn(vector.get(i)))
+    }
+    ArrowTensor(result, shape)
+  }
+
+  def zipWith(other: ArrowTensor)(fn: (Double, Double) => Double): ArrowTensor = {
+    if (other.shape != shape)
+      throw new IllegalArgumentException(s"Cannot zip tensors of differing sizes.  Got arguments of shape ${shape.mkString("×")} and ${other.shape.mkString("×")}")
+
+    val n = vector.getValueCount
+    val result = new Float8Vector("array", ArrowTensor.allocator)
+    result.allocateNew(n)
+    result.setValueCount(n)
+    cfor(0)(_ < n, _ + 1){ i =>
+      if (vector.isNull(i) || other.vector.isNull(i))
+        result.setNull(i)
+      else
+        result.set(i, fn(vector.get(i), other.vector.get(i)))
+    }
+    ArrowTensor(result, shape)
+  }
 
   /** Write Tensor to buffer, return offset of Tensor object in that buffer */
   def writeTensor(bufferBuilder: FlatBufferBuilder): Int = {
@@ -83,6 +124,8 @@ case class ArrowTensor(val vector: Float8Vector, val shape: Seq[Int]) extends Ce
 }
 
 object ArrowTensor {
+  val allocator = new RootAllocator(Long.MaxValue)
+
   val schema: Schema = {
     val fieldArr = new Field(
       "array",
@@ -93,7 +136,6 @@ object ArrowTensor {
   }
 
   def fromArray(arr: Array[Double], shape: Int*): ArrowTensor = {
-    val allocator = new RootAllocator(Long.MaxValue)
     val root = VectorSchemaRoot.create(schema, allocator)
     val vec = new Float8Vector("array", allocator)
     vec.allocateNew(arr.length)
@@ -103,8 +145,19 @@ object ArrowTensor {
     new ArrowTensor(vec, shape.toArray)
   }
 
+  def fill(v: Double, shape: Int*)(implicit alloc: BufferAllocator): ArrowTensor = {
+    val vec = new Float8Vector("array", alloc)
+    val shp = shape.toSeq
+    val n = shp.product
+    vec.allocateNew(n)
+    vec.setValueCount(n)
+    cfor(0)(_ < n, _ + 1){ i =>
+      vec.set(i, v)
+    }
+    ArrowTensor(vec, shp)
+  }
+
   def fromArrowMessage(bytes: Array[Byte]): ArrowTensor = {
-    val allocator = new RootAllocator(Integer.MAX_VALUE)
     val is = new ByteArrayInputStream(bytes)
     val channel = Channels.newChannel(is)
     val readChannel = new ReadChannel(channel)

--- a/core/src/main/scala/geotrellis/raster/ArrowTensor.scala
+++ b/core/src/main/scala/geotrellis/raster/ArrowTensor.scala
@@ -145,8 +145,8 @@ object ArrowTensor {
     new ArrowTensor(vec, shape.toArray)
   }
 
-  def fill(v: Double, shape: Int*)(implicit alloc: BufferAllocator): ArrowTensor = {
-    val vec = new Float8Vector("array", alloc)
+  def fill(v: Double, shape: Int*): ArrowTensor = {
+    val vec = new Float8Vector("array", allocator)
     val shp = shape.toSeq
     val n = shp.product
     vec.allocateNew(n)

--- a/core/src/main/scala/geotrellis/raster/ArrowTensor.scala
+++ b/core/src/main/scala/geotrellis/raster/ArrowTensor.scala
@@ -15,8 +15,11 @@ import org.apache.arrow.vector.{Float8Vector, VectorSchemaRoot}
 
 import scala.collection.JavaConverters._
 
-case class ArrowTensor(val vector: Float8Vector, val shape: Seq[Int]) {
+case class ArrowTensor(val vector: Float8Vector, val shape: Seq[Int]) extends CellGrid {
   // TODO: Should we be using ArrowBuf here directly, since Arrow Tensor can not have pages?
+  def rows = shape(1)
+  def cols = shape(2)
+  val cellType = DoubleCellType
 
   /** Write Tensor to buffer, return offset of Tensor object in that buffer */
   def writeTensor(bufferBuilder: FlatBufferBuilder): Int = {

--- a/core/src/main/scala/geotrellis/raster/ArrowTensor.scala
+++ b/core/src/main/scala/geotrellis/raster/ArrowTensor.scala
@@ -66,10 +66,9 @@ case class ArrowTensor(val vector: Float8Vector, val shape: Seq[Int]) extends Ce
   def writeTensor(bufferBuilder: FlatBufferBuilder): Int = {
     val elementSize = 8
 
-    // TODO: make work for more than 2 dimensions
-    // Array[Long](shape(0) * elementSize, elementSize)
+    // note the following relies on the data being Double
     val strides: Array[Long] = {
-      shape.reverse.map(_.toLong).toArray
+      shape.tails.toSeq.tail.map(_.product.toLong * 8L).toArray
     }
 
     val shapeOffset: Int = {
@@ -89,7 +88,7 @@ case class ArrowTensor(val vector: Float8Vector, val shape: Seq[Int]) extends Ce
 
     val stridesOffset = Tensor.createStridesVector(bufferBuilder, strides)
     Tensor.startTensor(bufferBuilder)
-    Tensor.addTypeType(bufferBuilder, Type.Int)
+    Tensor.addTypeType(bufferBuilder, Type.FloatingPoint)
     // pa.read_tensor also wants type, ND4j does not write this because it I'm guessing its not written to python
     Tensor.addType(bufferBuilder, typeOffset)
     Tensor.addShape(bufferBuilder, shapeOffset)

--- a/core/src/main/scala/org/apache/spark/sql/rf/TensorUDT.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rf/TensorUDT.scala
@@ -1,0 +1,90 @@
+/*
+ * This software is licensed under the Apache 2 license, quoted below.
+ *
+ * Copyright 2018 Azavea, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     [http://www.apache.org/licenses/LICENSE-2.0]
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.apache.spark.sql.rf
+import geotrellis.raster._
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.types.{DataType, _}
+import org.locationtech.rasterframes.encoders.CatalystSerializer
+import org.locationtech.rasterframes.encoders.CatalystSerializer._
+import org.locationtech.rasterframes.model.{Cells, TileDataContext}
+import org.locationtech.rasterframes.ref.RasterRef.RasterRefTile
+import org.locationtech.rasterframes.tiles.InternalRowTile
+
+
+/**
+  * UDT for singleband tiles.
+  *
+  * @since 11/18/19
+  */
+@SQLUserDefinedType(udt = classOf[TensorUDT])
+class TensorUDT extends UserDefinedType[ArrowTensor] {
+  import TensorUDT._
+  override def typeName = TensorUDT.typeName
+
+  override def pyUDT: String = "pyrasterframes.rf_types.TensorUDT"
+
+  def userClass: Class[ArrowTensor] = classOf[ArrowTensor]
+
+  def sqlType: StructType = schemaOf[ArrowTensor]
+
+  override def serialize(obj: ArrowTensor): InternalRow =
+    Option(obj)
+      .map(_.toInternalRow)
+      .orNull
+
+  override def deserialize(datum: Any): ArrowTensor =
+    Option(datum)
+      .collect {
+        case ir: InternalRow ⇒ ir.to[ArrowTensor]
+      }
+      .orNull
+
+  override def acceptsType(dataType: DataType): Boolean = dataType match {
+    case _: TensorUDT ⇒ true
+    case _ ⇒ super.acceptsType(dataType)
+  }
+}
+
+case object TensorUDT  {
+  UDTRegistration.register(classOf[ArrowTensor].getName, classOf[TensorUDT].getName)
+
+  final val typeName: String = "tensor"
+
+  implicit def tensorSerializer: CatalystSerializer[ArrowTensor] = new CatalystSerializer[ArrowTensor] {
+
+    override val schema: StructType = StructType(Seq(
+      StructField("arrow_tensor", BinaryType, true)
+    ))
+
+    override def to[R](t: ArrowTensor, io: CatalystIO[R]): R = io.create(
+      // TODO: encode ArrowTensor into bytes and Byte array here
+      Array.empty[Byte]
+    )
+
+    override def from[R](row: R, io: CatalystIO[R]): ArrowTensor = {
+      val bytes = io.getByteArray(row, 0)
+      ArrowTensor.fromArrowMessage(bytes)
+      // TODO: decode the arrow buffer here
+      ???
+    }
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/rf/TensorUDT.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rf/TensorUDT.scala
@@ -75,16 +75,13 @@ case object TensorUDT  {
       StructField("arrow_tensor", BinaryType, true)
     ))
 
-    override def to[R](t: ArrowTensor, io: CatalystIO[R]): R = io.create(
-      // TODO: encode ArrowTensor into bytes and Byte array here
-      Array.empty[Byte]
-    )
+    override def to[R](t: ArrowTensor, io: CatalystIO[R]): R = io.create {
+      t.toArrowBytes()
+    }
 
     override def from[R](row: R, io: CatalystIO[R]): ArrowTensor = {
       val bytes = io.getByteArray(row, 0)
       ArrowTensor.fromArrowMessage(bytes)
-      // TODO: decode the arrow buffer here
-      ???
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/rf/TensorUDT.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rf/TensorUDT.scala
@@ -30,11 +30,6 @@ import org.locationtech.rasterframes.ref.RasterRef.RasterRefTile
 import org.locationtech.rasterframes.tiles.InternalRowTile
 
 
-/**
-  * UDT for singleband tiles.
-  *
-  * @since 11/18/19
-  */
 @SQLUserDefinedType(udt = classOf[TensorUDT])
 class TensorUDT extends UserDefinedType[ArrowTensor] {
   import TensorUDT._

--- a/core/src/main/scala/org/apache/spark/sql/rf/package.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rf/package.scala
@@ -43,6 +43,7 @@ package object rf {
     // which is where the registration actually happens. The ordering matters!
     RasterSourceUDT
     TileUDT
+    TensorUDT
   }
 
   def registry(sqlContext: SQLContext): FunctionRegistry = {

--- a/core/src/main/scala/org/locationtech/rasterframes/RasterFunctions.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/RasterFunctions.scala
@@ -29,7 +29,7 @@ import org.apache.spark.annotation.Experimental
 import org.apache.spark.sql.functions.{lit, udf}
 import org.apache.spark.sql.{Column, TypedColumn}
 import org.locationtech.jts.geom.Geometry
-import org.locationtech.rasterframes.expressions.TileAssembler
+import org.locationtech.rasterframes.expressions.{StackTensors, TileAssembler}
 import org.locationtech.rasterframes.expressions.accessors._
 import org.locationtech.rasterframes.expressions.aggregates._
 import org.locationtech.rasterframes.expressions.generators._
@@ -556,4 +556,8 @@ trait RasterFunctions {
   /** Create a row for each cell in Tile with random sampling (no seed). */
   def rf_explode_tiles_sample(sampleFraction: Double, cols: Column*): Column =
     ExplodeTiles(sampleFraction, None, cols)
+
+  /* TENSOR FUNCTIONS --------------------------------------------------*/
+
+  def rf_stack_tensors(cols: Column*): Column = StackTensors(cols)
 }

--- a/core/src/main/scala/org/locationtech/rasterframes/StandardColumns.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/StandardColumns.scala
@@ -24,7 +24,7 @@ package org.locationtech.rasterframes
 import java.sql.Timestamp
 
 import geotrellis.proj4.CRS
-import geotrellis.raster.Tile
+import geotrellis.raster.{ArrowTensor, Tile}
 import geotrellis.spark.{SpatialKey, TemporalKey}
 import geotrellis.vector.{Extent, ProjectedExtent}
 import org.apache.spark.sql.functions.col
@@ -70,6 +70,10 @@ trait StandardColumns {
   /** Default RasterFrameLayer tile column name. */
   // This is a `def` because `TileUDT` needs to be initialized first.
   def TILE_COLUMN = col("tile").as[Tile]
+  /** Default RasterFrameLayer tile column name. */
+
+  // This is a `def` because `TileUDT` needs to be initialized first.
+  def TENSOR_COLUMN = col("tensor").as[ArrowTensor]
 
   /** Default column name for a tile with its CRS and Extent. */
   def PROJECTED_RASTER_COLUMN = col("proj_raster").as[ProjectedRasterTile]

--- a/core/src/main/scala/org/locationtech/rasterframes/encoders/StandardEncoders.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/encoders/StandardEncoders.scala
@@ -27,7 +27,7 @@ import java.sql.Timestamp
 import org.locationtech.rasterframes.stats.{CellHistogram, CellStatistics, LocalCellStatistics}
 import org.locationtech.jts.geom.Envelope
 import geotrellis.proj4.CRS
-import geotrellis.raster.{CellSize, CellType, Raster, Tile, TileLayout}
+import geotrellis.raster.{ArrowTensor, CellSize, CellType, Raster, Tile, TileLayout}
 import geotrellis.spark.tiling.LayoutDefinition
 import geotrellis.spark.{KeyBounds, SpaceTimeKey, SpatialKey, TemporalKey, TemporalProjectedExtent, TileLayerMetadata}
 import geotrellis.vector.{Extent, ProjectedExtent}
@@ -71,8 +71,7 @@ trait StandardEncoders extends SpatialEncoders {
   implicit def tileContextEncoder: ExpressionEncoder[TileContext] = TileContext.encoder
   implicit def tileDataContextEncoder: ExpressionEncoder[TileDataContext] = TileDataContext.encoder
   implicit def extentTilePairEncoder: Encoder[(ProjectedExtent, Tile)] = Encoders.tuple(projectedExtentEncoder, singlebandTileEncoder)
-
-
+  implicit def tensorEncoder: ExpressionEncoder[ArrowTensor] = ExpressionEncoder()
 }
 
 object StandardEncoders extends StandardEncoders

--- a/core/src/main/scala/org/locationtech/rasterframes/expressions/DynamicExtractors.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/expressions/DynamicExtractors.scala
@@ -143,7 +143,6 @@ object DynamicExtractors {
     extentExtractor.andThen(_.andThen(_.center.jtsGeom))
   }
 
-  sealed trait TileOrNumberArg
   sealed trait TensorTileOrNumberArg
   sealed trait TileOrNumberArg extends TensorTileOrNumberArg
   sealed trait NumberArg extends TileOrNumberArg

--- a/core/src/main/scala/org/locationtech/rasterframes/expressions/DynamicExtractors.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/expressions/DynamicExtractors.scala
@@ -22,12 +22,12 @@
 package org.locationtech.rasterframes.expressions
 
 import geotrellis.proj4.CRS
-import geotrellis.raster.{CellGrid, Tile}
+import geotrellis.raster.{CellGrid, Tile, ArrowTensor}
 import geotrellis.vector.Extent
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.jts.JTSTypes
-import org.apache.spark.sql.rf.{RasterSourceUDT, TileUDT}
+import org.apache.spark.sql.rf.{RasterSourceUDT, TensorUDT, TileUDT}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 import org.locationtech.jts.geom.{Envelope, Point}
@@ -82,6 +82,8 @@ object DynamicExtractors {
   lazy val gridExtractor: PartialFunction[DataType, InternalRow ⇒ CellGrid] = {
     case _: TileUDT =>
       (row: InternalRow) => row.to[Tile](TileUDT.tileSerializer)
+    case _: TensorUDT =>
+      (row: InternalRow) => row.to[ArrowTensor](TensorUDT.tensorSerializer)
     case _: RasterSourceUDT =>
       (row: InternalRow) => row.to[RasterSource](RasterSourceUDT.rasterSourceSerializer)
     case t if t.conformsTo[RasterRef] ⇒

--- a/core/src/main/scala/org/locationtech/rasterframes/expressions/StackTensors.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/expressions/StackTensors.scala
@@ -1,0 +1,45 @@
+package org.locationtech.rasterframes.expressions
+
+import geotrellis.raster.ArrowTensor
+import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.catalyst.expressions.{Expression, GenericInternalRow}
+import org.apache.spark.sql.rf._
+import org.apache.spark.sql.types._
+import org.locationtech.rasterframes._
+import org.locationtech.rasterframes.util._
+import spire.syntax.cfor.cfor
+
+case class StackTensors(override val children: Seq[Expression]) extends Expression with CodegenFallback {
+
+  override def nodeName: String = "rf_stack_tensors"
+  override def dataType: DataType = new TensorUDT
+  override def nullable: Boolean = true
+
+  override def eval(input: InternalRow): Any = {
+    if (input == null) null
+    else {
+      val tensors = Array.ofDim[ArrowTensor](children.length)
+      cfor(0)(_ < tensors.length, _ + 1) { i =>
+        val child = children(i)
+        val row = child.eval(input).asInstanceOf[InternalRow]
+        tensors(i) =
+          if (row != null)
+            DynamicExtractors.tensorExtractor(child.dataType)(row)._1
+          else
+            null  // TODO: is it better to throw here?
+      }
+      dataType.asInstanceOf[TensorUDT].serialize(ArrowTensor.stackTensors(tensors.filter(_ != null)))
+    }
+  }
+}
+
+object StackTensors {
+
+  def apply(cols: Seq[Column]): Column = {
+    val stacker = new StackTensors(cols.map(_.expr))
+    new Column(stacker).as("rf_stack_tensors")
+  }
+
+}

--- a/core/src/main/scala/org/locationtech/rasterframes/expressions/accessors/GetDimensions.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/expressions/accessors/GetDimensions.scala
@@ -23,7 +23,7 @@ package org.locationtech.rasterframes.expressions.accessors
 
 import org.locationtech.rasterframes.encoders.CatalystSerializer._
 import org.locationtech.rasterframes.expressions.OnCellGridExpression
-import geotrellis.raster.CellGrid
+import geotrellis.raster.{ArrowTensor, CellGrid}
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionDescription}
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback

--- a/core/src/main/scala/org/locationtech/rasterframes/expressions/localops/Add.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/expressions/localops/Add.scala
@@ -49,6 +49,7 @@ case class Add(left: Expression, right: Expression) extends BinaryLocalRasterOp
 
 
   override protected def op(left: ArrowTensor, right: ArrowTensor): ArrowTensor = left.zipWith(right)(_ + _)
+  override protected def op(left: ArrowTensor, right: Tile): ArrowTensor = left.zipBands(right)(_ + _)
   override protected def op(left: ArrowTensor, right: Double): ArrowTensor = left.map(_ + right)
   override protected def op(left: Tile, right: Tile): Tile = left.localAdd(right)
   override protected def op(left: Tile, right: Double): Tile = left.localAdd(right)

--- a/core/src/main/scala/org/locationtech/rasterframes/expressions/localops/Add.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/expressions/localops/Add.scala
@@ -48,9 +48,8 @@ case class Add(left: Expression, right: Expression) extends BinaryLocalRasterOp
   override val nodeName: String = "rf_local_add"
 
 
-  override protected def op(left: ArrowTensor, right: ArrowTensor): ArrowTensor = {
-    left.zipWith(right)(_ + _)
-  }
+  override protected def op(left: ArrowTensor, right: ArrowTensor): ArrowTensor = left.zipWith(right)(_ + _)
+  override protected def op(left: ArrowTensor, right: Double): ArrowTensor = left.map(_ + right)
   override protected def op(left: Tile, right: Tile): Tile = left.localAdd(right)
   override protected def op(left: Tile, right: Double): Tile = left.localAdd(right)
   override protected def op(left: Tile, right: Int): Tile = left.localAdd(right)

--- a/core/src/main/scala/org/locationtech/rasterframes/expressions/localops/Add.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/expressions/localops/Add.scala
@@ -21,7 +21,7 @@
 
 package org.locationtech.rasterframes.expressions.localops
 
-import geotrellis.raster.Tile
+import geotrellis.raster.{ArrowTensor, Tile}
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
@@ -46,6 +46,11 @@ import org.locationtech.rasterframes.expressions.DynamicExtractors.tileExtractor
 case class Add(left: Expression, right: Expression) extends BinaryLocalRasterOp
   with CodegenFallback {
   override val nodeName: String = "rf_local_add"
+
+
+  override protected def op(left: ArrowTensor, right: ArrowTensor): ArrowTensor = {
+    left.zipWith(right)(_ + _)
+  }
   override protected def op(left: Tile, right: Tile): Tile = left.localAdd(right)
   override protected def op(left: Tile, right: Double): Tile = left.localAdd(right)
   override protected def op(left: Tile, right: Int): Tile = left.localAdd(right)

--- a/core/src/main/scala/org/locationtech/rasterframes/rasterframes.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/rasterframes.scala
@@ -25,7 +25,7 @@ import com.typesafe.scalalogging.Logger
 import geotrellis.raster.{Tile, TileFeature, isData}
 import geotrellis.spark.{ContextRDD, Metadata, SpaceTimeKey, SpatialKey, TileLayerMetadata}
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.rf.{RasterSourceUDT, TileUDT}
+import org.apache.spark.sql.rf.{RasterSourceUDT, TensorUDT, TileUDT}
 import org.apache.spark.sql.{DataFrame, SQLContext, rf}
 import org.locationtech.geomesa.spark.jts.DataFrameFunctions
 import org.locationtech.rasterframes.encoders.StandardEncoders
@@ -85,6 +85,9 @@ package object rasterframes extends StandardColumns
 
   /** TileUDT type reference. */
   def TileType = new TileUDT()
+
+  /** TensorUDT type reference. */
+  def TensorType = new TensorUDT()
 
   /** RasterSourceUDT type reference. */
   def RasterSourceType = new RasterSourceUDT()

--- a/core/src/test/scala/org/locationtech/rasterframes/ArrowTensorSpec.scala
+++ b/core/src/test/scala/org/locationtech/rasterframes/ArrowTensorSpec.scala
@@ -1,0 +1,12 @@
+package org.locationtech.rasterframes
+
+import geotrellis.raster.ArrowTensor
+import org.scalatest._
+
+class ArrowTensorSpec extends FunSpec {
+  it("round trips through ipc message") {
+    val tensor = ArrowTensor.fromArray(Array(13),1, 1, 1)
+    val arr = tensor.toArrowBytes()
+    ArrowTensor.fromArrowMessage(arr)
+  }
+}

--- a/core/src/test/scala/org/locationtech/rasterframes/TensorUDTSpec.scala
+++ b/core/src/test/scala/org/locationtech/rasterframes/TensorUDTSpec.scala
@@ -1,0 +1,98 @@
+/*
+ * This software is licensed under the Apache 2 license, quoted below.
+ *
+ * Copyright 2017 Azavea, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     [http://www.apache.org/licenses/LICENSE-2.0]
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.locationtech.rasterframes
+import geotrellis.raster.{ArrowTensor, CellType, NoNoData, Tile}
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
+import org.apache.spark.sql.rf._
+import org.locationtech.rasterframes.encoders.CatalystSerializer._
+import org.scalatest.Inspectors
+
+/**
+  * RasterFrameLayer test rig.
+  *
+  * @since 11/18/2019
+  */
+class TensorUDTSpec extends TestEnvironment with TestData with Inspectors {
+
+  spark.version
+  val tensorEncoder: ExpressionEncoder[ArrowTensor] = ExpressionEncoder()
+  implicit val ser = TensorUDT.tensorSerializer
+
+  describe("TensorUDT") {
+    val tileSizes = Seq(2, 7, 64, 128, 511)
+    val ct = functions.cellTypes().filter(_ != "bool")
+
+//    it("should (de)serialize tile") {
+//      val tensor: ArrowTensor = ArrowTensor.fromArray(
+//        Array[Double](1,2,3,4), 2,2)
+//      val row = TensorType.serialize(tensor)
+//      val tensorAgain = TileType.deserialize(row)
+//      assert(tensorAgain === tensor)
+//    }
+//
+    it("should (en/de)code tile") {
+      val tensor: ArrowTensor = ArrowTensor.fromArray(
+        Array[Double](1,2,3,4), 2,2)
+      val row = tensorEncoder.toRow(tensor)
+      assert(!row.isNullAt(0))
+      val tileAgain = TensorType.deserialize(row.getStruct(0, TensorType.sqlType.size))
+      assert(tileAgain === tensor)
+    }
+//
+//    it("should extract properties") {
+//      forEveryConfig { tile ⇒
+//        val row = TileType.serialize(tile)
+//        val wrapper = row.to[Tile]
+//        assert(wrapper.cols === tile.cols)
+//        assert(wrapper.rows === tile.rows)
+//        assert(wrapper.cellType === tile.cellType)
+//      }
+//    }
+//
+//    it("should directly extract cells") {
+//      forEveryConfig { tile ⇒
+//        val row = TileType.serialize(tile)
+//        val wrapper = row.to[Tile]
+//        val (cols,rows) = wrapper.dimensions
+//        val indexes = Seq((0, 0), (cols - 1, rows - 1), (cols/2, rows/2), (1, 1))
+//        forAll(indexes) { case (c, r) ⇒
+//          assert(wrapper.get(c, r) === tile.get(c, r))
+//          assert(wrapper.getDouble(c, r) === tile.getDouble(c, r))
+//        }
+//      }
+//    }
+//
+//    it("should provide a pretty-print tile") {
+//      import spark.implicits._
+//      forEveryConfig { tile =>
+//        val stringified = Seq(tile).toDF("tile").select($"tile".cast(StringType)).as[String].first()
+//        stringified should be(ShowableTile.show(tile))
+//
+//        if(!tile.cellType.isInstanceOf[NoNoData]) {
+//          val withNd = tile.mutable
+//          withNd.update(0, raster.NODATA)
+//          ShowableTile.show(withNd) should include("--")
+//        }
+//      }
+//    }
+  }
+}

--- a/core/src/test/scala/org/locationtech/rasterframes/TensorUDTSpec.scala
+++ b/core/src/test/scala/org/locationtech/rasterframes/TensorUDTSpec.scala
@@ -20,17 +20,12 @@
  */
 
 package org.locationtech.rasterframes
-import geotrellis.raster.{ArrowTensor, CellType, NoNoData, Tile}
+import geotrellis.raster.ArrowTensor
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.rf._
 import org.locationtech.rasterframes.encoders.CatalystSerializer._
 import org.scalatest.Inspectors
 
-/**
-  * RasterFrameLayer test rig.
-  *
-  * @since 11/18/2019
-  */
 class TensorUDTSpec extends TestEnvironment with TestData with Inspectors {
 
   spark.version
@@ -38,62 +33,61 @@ class TensorUDTSpec extends TestEnvironment with TestData with Inspectors {
   implicit val ser = TensorUDT.tensorSerializer
 
   describe("TensorUDT") {
-    val tileSizes = Seq(2, 7, 64, 128, 511)
-    val ct = functions.cellTypes().filter(_ != "bool")
+    val sizes = Seq(1, 2, 4, 8, 11)
 
-//    it("should (de)serialize tile") {
-//      val tensor: ArrowTensor = ArrowTensor.fromArray(
-//        Array[Double](1,2,3,4), 2,2)
-//      val row = TensorType.serialize(tensor)
-//      val tensorAgain = TileType.deserialize(row)
-//      assert(tensorAgain === tensor)
-//    }
-//
-    it("should (en/de)code tile") {
-      val tensor: ArrowTensor  = ArrowTensor.fromArray(
-        Array[Double](1,2,3,4), 2,2)
-      val row = tensorEncoder.toRow(tensor)
-      assert(!row.isNullAt(0))
-      val tileAgain = TensorType.deserialize(row.getStruct(0, TensorType.sqlType.size))
-      assert(tileAgain.shape === tensor.shape)
-      assert(tileAgain.vector.get(0) === tensor.vector.get(0))
+    def forEveryConfig(test: ArrowTensor ⇒ Unit): Unit = {
+      forEvery(sizes.combinations(3).toSeq) { case Seq(xCount, yCount, zCount) ⇒
+        val arr = for {
+          xs <- Array.fill(xCount)(scala.math.random)
+          ys <- Array.fill(yCount)(scala.math.random)
+          zs <- Array.fill(zCount)(scala.math.random)
+        } yield {
+          xs * ys * zs
+        }
+        val tensor = ArrowTensor.fromArray(arr, xCount, yCount, zCount)
+          test(tensor)
+      }
     }
-//
-//    it("should extract properties") {
-//      forEveryConfig { tile ⇒
-//        val row = TileType.serialize(tile)
-//        val wrapper = row.to[Tile]
-//        assert(wrapper.cols === tile.cols)
-//        assert(wrapper.rows === tile.rows)
-//        assert(wrapper.cellType === tile.cellType)
-//      }
-//    }
-//
-//    it("should directly extract cells") {
-//      forEveryConfig { tile ⇒
-//        val row = TileType.serialize(tile)
-//        val wrapper = row.to[Tile]
-//        val (cols,rows) = wrapper.dimensions
-//        val indexes = Seq((0, 0), (cols - 1, rows - 1), (cols/2, rows/2), (1, 1))
-//        forAll(indexes) { case (c, r) ⇒
-//          assert(wrapper.get(c, r) === tile.get(c, r))
-//          assert(wrapper.getDouble(c, r) === tile.getDouble(c, r))
-//        }
-//      }
-//    }
-//
-//    it("should provide a pretty-print tile") {
-//      import spark.implicits._
-//      forEveryConfig { tile =>
-//        val stringified = Seq(tile).toDF("tile").select($"tile".cast(StringType)).as[String].first()
-//        stringified should be(ShowableTile.show(tile))
-//
-//        if(!tile.cellType.isInstanceOf[NoNoData]) {
-//          val withNd = tile.mutable
-//          withNd.update(0, raster.NODATA)
-//          ShowableTile.show(withNd) should include("--")
-//        }
-//      }
-//    }
+
+    it("should (en/de)code tile") {
+      forEveryConfig { tensor =>
+        val row = tensorEncoder.toRow(tensor)
+        assert(!row.isNullAt(0))
+        val tileAgain = TensorType.deserialize(row.getStruct(0, TensorType.sqlType.size))
+        assert(tileAgain.shape === tensor.shape)
+        assert(tileAgain.vector.get(0) === tensor.vector.get(0))
+      }
+    }
+
+    it("should extract properties") {
+      forEveryConfig { tensor =>
+        val row = TensorType.serialize(tensor)
+        val wrapper = row.to[ArrowTensor]
+        assert(wrapper.shape === tensor.shape)
+      }
+    }
+
+    it("should directly extract cells") {
+      forEveryConfig { tensor =>
+        val row = TensorType.serialize(tensor)
+        val wrapper = row.to[ArrowTensor]
+        val Seq(xCount, yCount, zCount) = wrapper.shape
+        for {
+          x <- 0 until xCount
+          y <- 0 until yCount
+          z <- 0 until zCount
+        } yield {
+          assert(wrapper.vector.get(x*y*z) === tensor.vector.get(x*y*z))
+        }
+      }
+    }
+
+    it("should round trip through a dataframe") {
+      import spark.implicits._
+      forEveryConfig { tensor =>
+        val df = Seq(tensor).toDF("tensor")
+        assert(df.select($"tensor").as[ArrowTensor].first().shape == tensor.shape)
+      }
+    }
   }
 }

--- a/core/src/test/scala/org/locationtech/rasterframes/TensorUDTSpec.scala
+++ b/core/src/test/scala/org/locationtech/rasterframes/TensorUDTSpec.scala
@@ -50,12 +50,13 @@ class TensorUDTSpec extends TestEnvironment with TestData with Inspectors {
 //    }
 //
     it("should (en/de)code tile") {
-      val tensor: ArrowTensor = ArrowTensor.fromArray(
+      val tensor: ArrowTensor  = ArrowTensor.fromArray(
         Array[Double](1,2,3,4), 2,2)
       val row = tensorEncoder.toRow(tensor)
       assert(!row.isNullAt(0))
       val tileAgain = TensorType.deserialize(row.getStruct(0, TensorType.sqlType.size))
-      assert(tileAgain === tensor)
+      assert(tileAgain.shape === tensor.shape)
+      assert(tileAgain.vector.get(0) === tensor.vector.get(0))
     }
 //
 //    it("should extract properties") {

--- a/project/RFProjectPlugin.scala
+++ b/project/RFProjectPlugin.scala
@@ -24,8 +24,7 @@ object RFProjectPlugin extends AutoPlugin {
     scalacOptions ++= Seq(
       "-feature",
       "-deprecation",
-      "-Ywarn-dead-code",
-      "-Ywarn-unused-import"
+      "-Ywarn-dead-code"
     ),
     scalacOptions in (Compile, doc) ++= Seq("-no-link-warnings"),
     console / scalacOptions := Seq("-feature"),

--- a/pyrasterframes/src/main/python/pyrasterframes/rasterfunctions.py
+++ b/pyrasterframes/src/main/python/pyrasterframes/rasterfunctions.py
@@ -138,6 +138,13 @@ def rf_explode_tiles_sample(sample_frac, seed, *tile_cols):
     return Column(jfcn(sample_frac, seed, RFContext.active().list_to_seq(jcols)))
 
 
+def rf_stack_tensors(*tile_cols):
+    """Join a set of tensors into a single tensor."""
+    jfcn = RFContext.active().lookup('rf_stack_tensors')
+    jcols = [_to_java_column(arg) for arg in tile_cols]
+    return Column(jfcn(RFContext.active().list_to_seq(jcols)))
+
+
 def _apply_scalar_to_tile(name, tile_col, scalar):
     jfcn = RFContext.active().lookup(name)
     return Column(jfcn(_to_java_column(tile_col), scalar))

--- a/pyrasterframes/src/main/python/pyrasterframes/rf_types.py
+++ b/pyrasterframes/src/main/python/pyrasterframes/rf_types.py
@@ -509,7 +509,7 @@ class TensorUDT(UserDefinedType):
     def deserialize(self, datum):
         br = pa.BufferReader(datum.arrow_tensor)
         tensor = pa.read_tensor(br)
-        ndarray = tensor.to_numpy(dtype='float64')
+        ndarray = tensor.to_numpy()
         return ArrowTensor(ndarray)
 
 

--- a/pyrasterframes/src/main/python/pyrasterframes/rf_types.py
+++ b/pyrasterframes/src/main/python/pyrasterframes/rf_types.py
@@ -459,6 +459,7 @@ class TileUDT(UserDefinedType):
             }, e)
         return t
 
+    deserialize.__safe_for_unpickling__ = True
 
 Tile.__UDT__ = TileUDT()
 
@@ -481,32 +482,6 @@ class NoDataFilter(JavaTransformer, HasInputCols, DefaultParamsReadable, Default
     def __init__(self):
         super(NoDataFilter, self).__init__()
         self._java_obj = self._new_java_obj("org.locationtech.rasterframes.ml.NoDataFilter", self.uid)
-
-
-class RasterSourceUDT(UserDefinedType):
-    @classmethod
-    def sqlType(cls):
-        return StructType([
-            StructField("raster_source_kryo", BinaryType(), False)])
-
-    @classmethod
-    def module(cls):
-        return 'pyrasterframes.rf_types'
-
-    @classmethod
-    def scalaUDT(cls):
-        return 'org.apache.spark.sql.rf.RasterSourceUDT'
-
-    def needConversion(self):
-        return False
-
-    # The contents of a RasterSource is opaque in the Python context.
-    # Just pass data through unmodified.
-    def serialize(self, obj):
-        return obj
-
-    def deserialize(self, datum):
-        return datum
 
 
 class TensorUDT(UserDefinedType):
@@ -536,8 +511,6 @@ class TensorUDT(UserDefinedType):
         tensor = pa.read_tensor(br)
         ndarray = tensor.to_numpy()
         return ArrowTensor(ndarray)
-
-    #deserialize.__safe_for_unpickling__ = True
 
 
 class ArrowTensor(object):

--- a/pyrasterframes/src/main/python/pyrasterframes/rf_types.py
+++ b/pyrasterframes/src/main/python/pyrasterframes/rf_types.py
@@ -509,7 +509,7 @@ class TensorUDT(UserDefinedType):
     def deserialize(self, datum):
         br = pa.BufferReader(datum.arrow_tensor)
         tensor = pa.read_tensor(br)
-        ndarray = tensor.to_numpy()
+        ndarray = tensor.to_numpy(dtype='float64')
         return ArrowTensor(ndarray)
 
 

--- a/pyrasterframes/src/main/python/tests/PyRasterFramesTests.py
+++ b/pyrasterframes/src/main/python/tests/PyRasterFramesTests.py
@@ -23,7 +23,7 @@ import unittest
 import numpy as np
 from pyrasterframes.rasterfunctions import *
 from pyrasterframes.rf_types import *
-from pyspark.sql import SQLContext
+from pyspark.sql import SQLContext, Row
 from pyspark.sql.functions import *
 from pyspark.sql import Row
 
@@ -99,6 +99,140 @@ class CellTypeHandling(unittest.TestCase):
                                  "GTCellType comparison for " + str(ct_ud)
                                  )
 
+
+class TestTensorUDT(TestEnvironment):
+
+    def test_tensor_udt_serialization(self):
+        from pyspark.sql.types import StructType, StructField
+
+        ndarray = (100 + np.random.randn(10, 10, 10) * 100).astype(np.dtype('float64'))
+        tensor = ArrowTensor(ndarray)
+
+        udt = TensorUDT()
+        round_trip = udt.fromInternal(udt.toInternal(tensor))
+        self.assertEqual(tensor, round_trip, "round-trip serialization")
+
+        df = self.spark.createDataFrame([Row(tens=tensor)])
+        long_trip = df.first().tens
+        self.assertEqual(long_trip, tensor)
+
+    def test_udf_on_tile_type_input(self):
+        import numpy.testing
+        df = self.spark.read.raster(self.img_uri)
+        rf = self.rf
+
+        # create trivial UDF that does something we already do with raster_Functions
+        @udf('integer')
+        def my_udf(t):
+            a = t.cells
+            return a.size  # same as rf_dimensions.cols * rf_dimensions.rows
+
+        rf_result = rf.select(
+            (rf_dimensions('tile').cols.cast('int') * rf_dimensions('tile').rows.cast('int')).alias('expected'),
+            my_udf('tile').alias('result')).toPandas()
+
+        numpy.testing.assert_array_equal(
+            rf_result.expected.tolist(),
+            rf_result.result.tolist()
+        )
+
+        df_result = df.select(
+            (rf_dimensions(df.proj_raster).cols.cast('int') * rf_dimensions(df.proj_raster).rows.cast('int') -
+                my_udf(rf_tile(df.proj_raster))).alias('result')
+        ).toPandas()
+
+        numpy.testing.assert_array_equal(
+            np.zeros(len(df_result)),
+            df_result.result.tolist()
+        )
+
+'''
+    def test_udf_on_tile_type_output(self):
+        import numpy.testing
+
+        rf = self.rf
+
+        # create a trivial UDF that does something we already do with a raster_functions
+        @udf(TileUDT())
+        def my_udf(t):
+            import numpy as np
+            return Tile(np.log1p(t.cells))
+
+        rf_result = rf.select(
+            rf_tile_max(
+                rf_local_subtract(
+                    my_udf(rf.tile),
+                    rf_log1p(rf.tile)
+                )
+            ).alias('expect_zeros')
+        ).collect()
+
+        # almost equal because of different implemenations under the hoods: C (numpy) versus Java (rf_)
+        numpy.testing.assert_almost_equal(
+            [r['expect_zeros'] for r in rf_result],
+            [0.0 for _ in rf_result],
+            decimal=6
+        )
+
+    def test_no_data_udf_handling(self):
+        from pyspark.sql.types import StructType, StructField
+
+        t1 = Tile(np.array([[1, 2], [0, 4]]), CellType.uint8())
+        self.assertEqual(t1.cell_type.to_numpy_dtype(), np.dtype("uint8"))
+        e1 = Tile(np.array([[2, 3], [0, 5]]), CellType.uint8())
+        schema = StructType([StructField("tile", TileUDT(), False)])
+        df = self.spark.createDataFrame([{"tile": t1}], schema)
+
+        @udf(TileUDT())
+        def increment(t):
+            return t + 1
+
+        r1 = df.select(increment(df.tile).alias("inc")).first()["inc"]
+        self.assertEqual(r1, e1)
+
+    def test_udf_np_implicit_type_conversion(self):
+        import math
+        import pandas
+
+        a1 = np.array([[1, 2], [0, 4]])
+        t1 = Tile(a1, CellType.uint8())
+        exp_array = a1.astype('>f8')
+
+        @udf(TileUDT())
+        def times_pi(t):
+            return t * math.pi
+
+        @udf(TileUDT())
+        def divide_pi(t):
+            return t / math.pi
+
+        @udf(TileUDT())
+        def plus_pi(t):
+            return t + math.pi
+
+        @udf(TileUDT())
+        def less_pi(t):
+            return t - math.pi
+
+        df = self.spark.createDataFrame(pandas.DataFrame([{"tile": t1}]))
+        r1 = df.select(
+            less_pi(divide_pi(times_pi(plus_pi(df.tile))))
+        ).first()[0]
+
+        self.assertTrue(np.all(r1.cells == exp_array))
+        self.assertEqual(r1.cells.dtype, exp_array.dtype)
+
+    def test_pandas_udf(self):
+        from pyspark.sql.functions import pandas_udf, PandasUDFType
+
+        @pandas_udf('double', PandasUDFType.SCALAR)
+        def tile_mean(cells):
+            # `cells` is a Pandas `Series`.
+            return cells.apply(np.mean)
+
+        df = self.rf.select(tile_mean(self.rf.tile).alias('pandas_udf_mean'))
+        df.show(truncate=False)
+'''
 
 class UDT(TestEnvironment):
 

--- a/pyrasterframes/src/main/python/tests/PyRasterFramesTests.py
+++ b/pyrasterframes/src/main/python/tests/PyRasterFramesTests.py
@@ -262,6 +262,16 @@ class UDT(TestEnvironment):
         self.assertTrue(np.all(r1.cells == exp_array))
         self.assertEqual(r1.cells.dtype, exp_array.dtype)
 
+    def test_pandas_udf(self):
+        from pyspark.sql.functions import pandas_udf, PandasUDFType
+
+        @pandas_udf('double', PandasUDFType.SCALAR)
+        def tile_mean(cells):
+            # `cells` is a Pandas `Series`.
+            return cells.apply(np.mean)
+
+        df = self.rf.select(tile_mean(self.rf.tile).alias('pandas_udf_mean'))
+        df.show(truncate=False)
 
 class TileOps(TestEnvironment):
 

--- a/pyrasterframes/src/main/python/tests/__init__.py
+++ b/pyrasterframes/src/main/python/tests/__init__.py
@@ -42,7 +42,7 @@ def resource_dir():
     rez_dir = os.path.realpath(os.path.join(scala_target, 'test-classes'))
     # If not running in build mode, try source dirs.
     if not os.path.exists(rez_dir):
-        rez_dir = os.path.realpath(os.path.join(pdir(pdir(pdir(here))), 'test', 'resources'))
+        rez_dir = os.path.realpath(os.path.join(pdir(pdir(pdir(here))), 'src', 'test', 'resources'))
     return rez_dir
 
 


### PR DESCRIPTION
Prototype to use Arrow Tensor IPC message to add a tensor UDT.

The aim are twofold:
- Add a tensor UDT which is the main objective for our target workflows
- Use some kind of arrow encoding in hopes that it can be improved on

Its worth noting that in current world the bytes will still passed through python pickler on the way to python executors, which can't be great for performance. 

The work is based on mocking around here: https://github.com/echeipesh/py2j-arrow/tree/feature/tensor-ipc-roundtrip
