### PR TITLE
Add support for buffered tensors

### DIFF
--- a/core/src/main/scala/geotrellis/raster/BufferedTensor.scala
+++ b/core/src/main/scala/geotrellis/raster/BufferedTensor.scala
@@ -1,0 +1,33 @@
+package geotrellis.raster
+
+import geotrellis.vector.Extent
+
+// trait CellAddressable[T] {
+//   def get(col: Int, row: Int): Int
+//   def getDouble(col: Int, row: Int): Int
+// }
+
+// implicit class cellAddressableTile(t: Tile) extends CellAddressable[Tile]
+
+/**
+ * Container used to interpret the underlying cell data as having a buffer
+ * region around the tile perimeter.
+ *
+ * @param tile: The raster data, including buffer
+ * @param extent: The extent of the "core" data, not including the buffer cells
+ * @param bufferSize: The number of cells around the boundary that are
+ * considered as buffer data
+ */
+case class BufferedTensor(val tile: ArrowTensor, val bufferCols: Int, val bufferRows: Int, val extent: Option[Extent]) extends CellGrid {
+
+  val cellType = DoubleCellType
+
+  val cols = tile.cols - bufferCols * 2
+  val rows = tile.rows - bufferRows * 2
+  val rasterExtent = extent.map(RasterExtent(_, cols, rows))
+
+  lazy val bufferedCols = tile.cols
+  lazy val bufferedRows = tile.rows
+  lazy val bufferedExtent = extent.map(_.expandBy(rasterExtent.get.cellwidth * bufferCols,
+                                       rasterExtent.get.cellheight * bufferRows))
+}

--- a/core/src/main/scala/org/apache/spark/sql/rf/BufferedTensorUDT.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rf/BufferedTensorUDT.scala
@@ -1,0 +1,103 @@
+/*
+ * This software is licensed under the Apache 2 license, quoted below.
+ *
+ * Copyright 2018 Azavea, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     [http://www.apache.org/licenses/LICENSE-2.0]
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.apache.spark.sql.rf
+import geotrellis.raster._
+import geotrellis.vector.Extent
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.types.{DataType, _}
+import org.locationtech.rasterframes.encoders.CatalystSerializer
+import org.locationtech.rasterframes.encoders.CatalystSerializer._
+import org.locationtech.rasterframes.model.{Cells, TileDataContext}
+import org.locationtech.rasterframes.ref.RasterRef.RasterRefTile
+import org.locationtech.rasterframes.tiles.InternalRowTile
+
+import com.typesafe.scalalogging.Logger
+import org.slf4j.LoggerFactory
+
+@SQLUserDefinedType(udt = classOf[TensorUDT])
+class BufferedTensorUDT extends UserDefinedType[BufferedTensor] {
+  import BufferedTensorUDT._
+  override def typeName = BufferedTensorUDT.typeName
+
+  override def pyUDT: String = "pyrasterframes.rf_types.BufferedTensorUDT"
+
+  def userClass: Class[BufferedTensor] = classOf[BufferedTensor]
+
+  def sqlType: StructType = schemaOf[BufferedTensor]
+
+  override def serialize(obj: BufferedTensor): InternalRow =
+    Option(obj)
+      .map(_.toInternalRow)
+      .orNull
+
+  override def deserialize(datum: Any): BufferedTensor = {
+    logger.warn(s"Deserializing from $datum")
+    Option(datum)
+      .collect {
+        case ir: InternalRow ⇒ ir.to[BufferedTensor]
+      }
+      .orNull
+  }
+
+  override def acceptsType(dataType: DataType): Boolean = dataType match {
+    case _: BufferedTensorUDT ⇒ true
+    case _ ⇒ super.acceptsType(dataType)
+  }
+}
+
+case object BufferedTensorUDT  {
+  @transient protected lazy val logger = Logger(LoggerFactory.getLogger(getClass.getName))
+
+  UDTRegistration.register(classOf[BufferedTensor].getName, classOf[BufferedTensorUDT].getName)
+  logger.warn(s"Registered BufferedTensor")
+
+  final val typeName: String = "tensor"
+
+  implicit def bufferedTensorSerializer: CatalystSerializer[BufferedTensor] = new CatalystSerializer[BufferedTensor] {
+
+    override val schema: StructType = StructType(Seq(
+      StructField("arrow_tensor", BinaryType, false),
+      StructField("extent", schemaOf[Extent], true),
+      StructField("x_buffer", IntegerType, false),
+      StructField("y_buffer", IntegerType, false)
+    ))
+
+    override def to[R](t: BufferedTensor, io: CatalystIO[R]): R = {
+      logger.warn(s"Encoding BufferedTensor to row instancex")
+      io.create (
+        t.tile.toArrowBytes(),
+        io.to(t.extent.getOrElse(null)),
+        t.bufferCols,
+        t.bufferRows
+      )
+    }
+
+    override def from[R](row: R, io: CatalystIO[R]): BufferedTensor = {
+      logger.warn(s"Deserializing from $row")
+      val bytes = io.getByteArray(row, 0)
+      val extent = if (io.isNullAt(row, 1)) None else Some(io.get[Extent](row, 1))
+      val bx = io.getInt(row, 2)
+      val by = io.getInt(row, 3)
+      new BufferedTensor(ArrowTensor.fromArrowMessage(bytes), bx, by, extent)
+    }
+  }
+}

--- a/core/src/main/scala/org/locationtech/rasterframes/expressions/DynamicExtractors.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/expressions/DynamicExtractors.scala
@@ -22,12 +22,12 @@
 package org.locationtech.rasterframes.expressions
 
 import geotrellis.proj4.CRS
-import geotrellis.raster.{CellGrid, Tile, ArrowTensor}
+import geotrellis.raster.{CellGrid, Tile, ArrowTensor, BufferedTensor}
 import geotrellis.vector.Extent
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.jts.JTSTypes
-import org.apache.spark.sql.rf.{RasterSourceUDT, TensorUDT, TileUDT}
+import org.apache.spark.sql.rf.{RasterSourceUDT, BufferedTensorUDT, TensorUDT, TileUDT}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 import org.locationtech.jts.geom.{Envelope, Point}
@@ -96,6 +96,8 @@ object DynamicExtractors {
       (row: InternalRow) => row.to[Tile](TileUDT.tileSerializer)
     case _: TensorUDT =>
       (row: InternalRow) => row.to[ArrowTensor](TensorUDT.tensorSerializer)
+    case _: BufferedTensorUDT =>
+      (row: InternalRow) => row.to[BufferedTensor](BufferedTensorUDT.bufferedTensorSerializer)
     case _: RasterSourceUDT =>
       (row: InternalRow) => row.to[RasterSource](RasterSourceUDT.rasterSourceSerializer)
     case t if t.conformsTo[RasterRef] ⇒

--- a/pyrasterframes/src/main/python/pyrasterframes/rf_types.py
+++ b/pyrasterframes/src/main/python/pyrasterframes/rf_types.py
@@ -611,6 +611,8 @@ class BufferedTensor(object):
             # Bandwise convolution
             if mask.shape[0] % 2 == 0 or mask.shape[1] % 2 == 0:
                 raise ValueError("Convolution on buffered tiles requires odd mask dimensions")
+            if self.buffer_rows < (mask.shape[0] - 1) / 2 or self.buffer_cols <- (mask.shape[1] - 1) / 2:
+                raise ValueError("Tensor has insufficient buffer for convolution operation")
 
             filtered = np.stack([signal.convolve(self.ndarray[band,:,:], mask, mode='valid') for band in range(self.ndarray.shape[0])])
             new_buffer_rows = self.buffer_rows - (mask.shape[0] - 1) / 2
@@ -619,6 +621,8 @@ class BufferedTensor(object):
             # Expert mode volume convolution (changes number of bands)
             if mask.shape[1] % 2 == 0 or mask.shape[2] % 2 == 0:
                 raise ValueError("Convolution on buffered tiles requires odd mask row × col dimensions")
+            if self.buffer_rows < (mask.shape[1] - 1) / 2 or self.buffer_cols <- (mask.shape[2] - 1) / 2:
+                raise ValueError("Tensor has insufficient buffer for convolution operation")
 
             filtered = signal.convolve(self.ndarray, mask, mode='valid')
             new_buffer_rows = self.buffer_rows - (mask.shape[1] - 1) / 2


### PR DESCRIPTION
This PR introduced a BufferedTensor class on both the Python and Scala sides.  This is largely to facilitate focal operations (yet to come).  We can create a BufferedTensor with non-uniform buffers (i.e., rows and columns have a different amount of buffering).  In python, these objects can be convolved over, and this operation will automatically erode the buffer.  This will be useful in the interim for implementing focal operations via UDFs in Python until they are implemented properly via Catalyst.