### PR TITLE
Tensor explode

### DIFF
--- a/core/src/main/scala/geotrellis/raster/ArrowTensor.scala
+++ b/core/src/main/scala/geotrellis/raster/ArrowTensor.scala
@@ -13,6 +13,7 @@ import org.apache.arrow.vector.types.FloatingPointPrecision
 import org.apache.arrow.vector.types.pojo.{ArrowType, Field, FieldType, Schema}
 import org.apache.arrow.vector.{Float8Vector, VectorSchemaRoot}
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
+import org.apache.spark.mllib.linalg.{Vector, Vectors}
 
 import org.locationtech.rasterframes.encoders.CatalystSerializerEncoder
 
@@ -86,6 +87,21 @@ case class ArrowTensor(val vector: Float8Vector, val shape: Seq[Int]) extends Ce
       }
     }
     ArrowTensor(result, shape)
+  }
+
+  def getPixelVector(col: Int, row: Int): Vector = {
+    val pixelStack =
+      for (depth <- 0 until shape(0)) yield {
+    //    println("handling depth: ", depth)
+        val i = depth * row * col
+        if (vector.isNull(i))
+          Double.NaN
+        else
+          vector.get(i)
+      }
+   //   println("pixel stack", pixelStack.toList)
+
+    Vectors.dense(pixelStack.toArray)
   }
 
   def sliceBands(bands: Seq[Int]): ArrowTensor = {

--- a/core/src/main/scala/org/apache/spark/sql/rf/BufferedTensorUDT.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rf/BufferedTensorUDT.scala
@@ -66,7 +66,7 @@ class BufferedTensorUDT extends UserDefinedType[BufferedTensor] {
   }
 }
 
-case object BufferedTensorUDT  {
+object BufferedTensorUDT  {
   @transient protected lazy val logger = Logger(LoggerFactory.getLogger(getClass.getName))
 
   UDTRegistration.register(classOf[BufferedTensor].getName, classOf[BufferedTensorUDT].getName)

--- a/core/src/main/scala/org/locationtech/rasterframes/RasterFunctions.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/RasterFunctions.scala
@@ -560,4 +560,16 @@ trait RasterFunctions {
   /* TENSOR FUNCTIONS --------------------------------------------------*/
 
   def rf_stack_tensors(cols: Column*): Column = StackTensors(cols)
+
+  /** Create a row for each set of cells in 2d Tensor slice. */
+  def rf_explode_tensor(col: Column): Column =
+    rf_explode_tensor_sample(col, 1.0, None)
+
+  /** Create a row for each set of cells in 2d Tensor slice with random sampling. */
+  def rf_explode_tensor_sample(col: Column, sampleFraction: Double): Column =
+    rf_explode_tensor_sample(col, sampleFraction, None)
+
+  /** Create a row for each set of cells in 2d Tensor slice with random sampling (optional seed). */
+  def rf_explode_tensor_sample(col: Column, sampleFraction: Double, seed: Option[Long]): Column =
+    ExplodeTensor(col, sampleFraction, seed)
 }

--- a/core/src/main/scala/org/locationtech/rasterframes/expressions/DynamicExtractors.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/expressions/DynamicExtractors.scala
@@ -50,6 +50,18 @@ object DynamicExtractors {
     //   }
   }
 
+  lazy val bufferedTensorExtractor: PartialFunction[DataType, InternalRow => (BufferedTensor, Option[TileContext])] = {
+    case _: BufferedTensorUDT =>
+      (row: InternalRow) =>
+        (row.to[BufferedTensor](BufferedTensorUDT.bufferedTensorSerializer), None)
+    // We could use something like the following to associate a projection with a Tensor
+    // case t if t.conformsTo[ProjectedRasterTile] =>
+    //   (row: InternalRow) => {
+    //     val prt = row.to[ProjectedRasterTile]
+    //     (prt, Some(TileContext(prt)))
+    //   }
+  }
+
   /** Partial function for pulling a tile and its context from an input row. */
   lazy val tileExtractor: PartialFunction[DataType, InternalRow => (Tile, Option[TileContext])] = {
     case _: TileUDT =>

--- a/core/src/main/scala/org/locationtech/rasterframes/expressions/generators/ExplodeTensor.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/expressions/generators/ExplodeTensor.scala
@@ -41,12 +41,12 @@ import org.apache.spark.ml.linalg.SQLDataTypes.VectorType
  *
  * @since 4/12/17
  */
-case class ExplodeTensors(
-  sampleFraction: Double , seed: Option[Long], override val child: Expression)
-  extends UnaryExpression with Generator with CodegenFallback with ExpectsInputTypes {
+case class ExplodeTensor(
+  override val child: Expression, sampleFraction: Double , seed: Option[Long]
+) extends UnaryExpression with Generator with CodegenFallback with ExpectsInputTypes {
 
-  def this(child: Expression) = this(1.0, None, child)
-  override def nodeName: String = "rf_explode_tensors"
+  def this(child: Expression) = this(child, 1.0, None)
+  override def nodeName: String = "rf_explode_tensor"
 
   override def inputTypes: Seq[DataType] = Seq(BufferedTensorType)
 
@@ -98,13 +98,13 @@ case class ExplodeTensors(
   }
 }
 
-object ExplodeTensors {
+object ExplodeTensor {
   def apply(col: Column): Column = {
-    ExplodeTensors(1.0, None, col)
+    ExplodeTensor(col, 1.0, None)
   }
 
-  def apply(sampleFraction: Double, seed: Option[Long], col: Column): Column = {
-    val exploder = new ExplodeTensors(sampleFraction, seed, col.expr)
+  def apply(col: Column, sampleFraction: Double, seed: Option[Long]): Column = {
+    val exploder = new ExplodeTensor(col.expr, sampleFraction, seed)
     new Column(exploder)
   }
 }

--- a/core/src/main/scala/org/locationtech/rasterframes/expressions/generators/ExplodeTensors.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/expressions/generators/ExplodeTensors.scala
@@ -1,0 +1,113 @@
+/*
+ * This software is licensed under the Apache 2 license, quoted below.
+ *
+ * Copyright 2019 Astraea, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     [http://www.apache.org/licenses/LICENSE-2.0]
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.locationtech.rasterframes.expressions.generators
+
+import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.catalyst.expressions.{UnaryExpression, Expression, Generator, GenericInternalRow, ExpectsInputTypes}
+import org.apache.spark.sql.types._
+import org.locationtech.rasterframes._
+import org.locationtech.rasterframes.expressions.DynamicExtractors
+import org.locationtech.rasterframes.util._
+import spire.syntax.cfor.cfor
+
+import geotrellis.raster.BufferedTensor
+
+import org.apache.spark.mllib.linalg.VectorUDT
+import org.apache.spark.ml.linalg.SQLDataTypes.VectorType
+/**
+ * Catalyst expression for converting a tensor column into a vector column, with each tensor pixel-stack
+ *  occupying a separate row as an MLLib vector.
+ *
+ * @since 4/12/17
+ */
+case class ExplodeTensors(
+  sampleFraction: Double , seed: Option[Long], override val child: Expression)
+  extends UnaryExpression with Generator with CodegenFallback with ExpectsInputTypes {
+
+  def this(child: Expression) = this(1.0, None, child)
+  override def nodeName: String = "rf_explode_tensors"
+
+  override def inputTypes: Seq[DataType] = Seq(BufferedTensorType)
+
+  override def elementSchema: StructType =
+    StructType(
+      Seq(
+        StructField(COLUMN_INDEX_COLUMN.columnName, IntegerType, false),
+        StructField(ROW_INDEX_COLUMN.columnName, IntegerType, false),
+        StructField("vector", VectorType, false)
+      )
+    )
+
+  private def sample[T](things: Seq[T]) = {
+    // Apply random seed if provided
+    seed.foreach(s ⇒ scala.util.Random.setSeed(s))
+    scala.util.Random.shuffle(things)
+      .take(math.ceil(things.length * sampleFraction).toInt)
+  }
+
+  override def eval(input: InternalRow): TraversableOnce[InternalRow] = {
+    val row = child.eval(input).asInstanceOf[InternalRow]
+    val bufTensor =
+      if(row != null)
+        DynamicExtractors.bufferedTensorExtractor(child.dataType)(row)._1
+      else throw new Exception("I don't know.")
+
+    //val bufTensor = child.eval(input).asInstanceOf[BufferedTensor]
+
+    val depth = bufTensor.tensor.shape(0)
+    val cols = bufTensor.tensor.shape(1)
+    val rows = bufTensor.tensor.shape(2)
+
+    val udt = new VectorUDT()
+    val retval = Array.ofDim[InternalRow](cols * rows)
+    cfor(0)(_ < cols, _ + 1) { col =>
+      cfor(0)(_ < rows, _ + 1) { row =>
+        cfor(0)(_ < depth, _ + 1) { band =>
+          val rowIndex = row * cols + col
+          val index = band * row * col
+          val outCols = Array.ofDim[Any](3)
+          outCols(0) = col
+          outCols(1) = row
+          outCols(2) = udt.serialize(bufTensor.tensor.getPixelVector(col, row))
+          retval(rowIndex) = new GenericInternalRow(outCols)
+          //outCols(index + 2) = if(tile == null) doubleNODATA else tile.getDouble(col, row)
+        }
+      }
+    }
+    if(sampleFraction > 0.0 && sampleFraction < 1.0) sample(retval)
+    else retval
+  }
+}
+
+object ExplodeTensors {
+  def apply(col: Column): Column = {
+    ExplodeTensors(1.0, None, col)
+  }
+
+  def apply(sampleFraction: Double, seed: Option[Long], col: Column): Column = {
+    val exploder = new ExplodeTensors(sampleFraction, seed, col.expr)
+    // Hack to grab the first two non-cell columns, containing the column and row indexes
+    new Column(exploder)
+  }
+}

--- a/core/src/main/scala/org/locationtech/rasterframes/expressions/generators/RasterSourcesToTensorRefs.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/expressions/generators/RasterSourcesToTensorRefs.scala
@@ -74,7 +74,7 @@ case class RasterSourcesToTensorRefs(child: Expression, subtileDims: Option[Tile
         })
         result
       }
-      println(s"Got arr=$rss")
+      println(s"Got arr=${rss.toList}")
 
       val sampleRS = rss.head.source
 

--- a/core/src/main/scala/org/locationtech/rasterframes/expressions/package.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/expressions/package.scala
@@ -65,6 +65,7 @@ package object expressions {
     registry.registerExpression[Subtract]("rf_local_subtract")
     registry.registerExpression[TileAssembler]("rf_assemble_tile")
     registry.registerExpression[ExplodeTiles]("rf_explode_tiles")
+    registry.registerExpression[ExplodeTensor]("rf_explode_tensor")
     registry.registerExpression[GetCellType]("rf_cell_type")
     registry.registerExpression[SetCellType]("rf_convert_cell_type")
     registry.registerExpression[InterpretAs]("rf_interpret_cell_type_as")

--- a/core/src/main/scala/org/locationtech/rasterframes/expressions/transformers/PatternToRasterSources.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/expressions/transformers/PatternToRasterSources.scala
@@ -72,8 +72,7 @@ case class PatternToRasterSources(override val child: Expression, bands: Option[
           .getOrElse(Seq(0))
           .map((pattern, _))
       }
-
-    val expanded = sources.map{ case (str, bnd) => RasterSourceWithBand(RasterSource(URI.create(str)), bnd) }
+    val expanded = sources.map({ case (str, bnd) => RasterSourceWithBand(RasterSource(URI.create(str)), bnd) })
 
     new GenericArrayData(expanded.map(_.toInternalRow))
   }

--- a/datasource/src/main/scala/org/locationtech/rasterframes/datasource/tensor/TensorRelation.scala
+++ b/datasource/src/main/scala/org/locationtech/rasterframes/datasource/tensor/TensorRelation.scala
@@ -85,9 +85,6 @@ case class TensorRelation(
       catalog.select(refs).select(tens)
     }
 
-    println("This is the schema:")
-    df.printSchema
-
     if (spatialIndexPartitions.isDefined) {
       val indexed = df
         .withColumn("spatial_index", XZ2Indexer(GetExtent(col("tensor_ref")), GetCRS(col("tensor_ref"))))

--- a/datasource/src/test/scala/org/locationtech/rasterframes/datasource/tensor/TensorDataSourceSpec.scala
+++ b/datasource/src/test/scala/org/locationtech/rasterframes/datasource/tensor/TensorDataSourceSpec.scala
@@ -113,6 +113,25 @@ class TensorDataSourceSpec extends TestEnvironment with TestData {
       // val ds = df.as[ProjectedBufferedTensor]
       // ds.first.tensor.bufferCols shouldBe (buffer)
     }
+    it("should make a bunch of vectors") {
+      import org.locationtech.rasterframes.expressions.transformers._
+      val buffer = 2
+      val df = spark.read
+        .tensor
+        .from("file:/tmp/tif-%02d.tif")
+        .withBandIndexes(0, 1, 2)
+        .withBuffer(buffer)
+        .withTileDimensions(128,128)
+        .load()
+
+      df.printSchema
+      df.show
+
+      import org.locationtech.rasterframes.expressions.generators.ExplodeTensors
+      val exploded = df.select(ExplodeTensors(col("tensor")))
+      exploded.printSchema
+      exploded.show(2000)
+    }
   //   it("should read a multiband file") {
   //     val df = spark.read
   //       .raster

--- a/datasource/src/test/scala/org/locationtech/rasterframes/datasource/tensor/TensorDataSourceSpec.scala
+++ b/datasource/src/test/scala/org/locationtech/rasterframes/datasource/tensor/TensorDataSourceSpec.scala
@@ -127,8 +127,25 @@ class TensorDataSourceSpec extends TestEnvironment with TestData {
       df.printSchema
       df.show
 
-      import org.locationtech.rasterframes.expressions.generators.ExplodeTensors
-      val exploded = df.select(ExplodeTensors(col("tensor")))
+      val exploded = df.select(rf_explode_tensor(col("tensor")))
+      exploded.printSchema
+      exploded.show(2000)
+    }
+    it("should make a bunch of vectors") {
+      import org.locationtech.rasterframes.expressions.transformers._
+      val buffer = 2
+      val df = spark.read
+        .tensor
+        .from("file:/tmp/tif-%02d.tif")
+        .withBandIndexes(0, 1, 2)
+        .withBuffer(buffer)
+        .withTileDimensions(128,128)
+        .load()
+
+      df.printSchema
+      df.show
+
+      val exploded = df.select(rf_explode_tensor(col("tensor")))
       exploded.printSchema
       exploded.show(2000)
     }

--- a/pyrasterframes/src/main/python/pyrasterframes/__init__.py
+++ b/pyrasterframes/src/main/python/pyrasterframes/__init__.py
@@ -250,14 +250,6 @@ def _tensor_reader(
         expand_pattern=False,
         **options):
     """
-    Returns a Spark DataFrame from raster data files specified by URIs.
-    Each row in the returned DataFrame will contain a column with struct of (CRS, Extent, Tile) for each item in
-      `catalog_col_names`.
-    Multiple bands from the same raster file are spread across rows of the DataFrame. See `band_indexes` param.
-    If bands from a scene are stored in separate files, provide a DataFrame to the `path` parameter.
-
-    For more details and example usage, consult https://rasterframes.io/raster-read.html
-
     :param path: a (optionally comma-delimeted) string or list of strings giving URI patterns to the raster data to read.  Patterns will be formatted in printf style with a single '%d' format specifier where the band number will be used to exand the pattern into the final source file name.  Must specify band_indexes for the expansion to occur.
     :param band_indexes: list of zero-based indexes used for pattern expansion.  If omitted, pattern expansion will be skipped.
     :param tile_dimensions: tuple or list of two indicating the default tile dimension as (rows, columns).

--- a/pyrasterframes/src/main/python/pyrasterframes/rasterfunctions.py
+++ b/pyrasterframes/src/main/python/pyrasterframes/rasterfunctions.py
@@ -138,6 +138,20 @@ def rf_explode_tiles_sample(sample_frac, seed, *tile_cols):
     return Column(jfcn(sample_frac, seed, RFContext.active().list_to_seq(jcols)))
 
 
+def rf_explode_tensor(tensor_col):
+    """Create a row for each cell in Tile."""
+    jfcn = RFContext.active().lookup('rf_explode_tensor')
+    jcol = _to_java_column(tensor_col)
+    return Column(jfcn(jcol))
+
+
+def rf_explode_tensor_sample(sample_frac, seed, tensor_col):
+    """Create a row for a sample of cells in Tile columns."""
+    jfcn = RFContext.active().lookup('rf_explode_tensor_sample')
+    jcol = _to_java_column(tensor_col)
+    return Column(jfcn(jcol, sample_frac, seed))
+
+
 def rf_stack_tensors(*tile_cols):
     """Join a set of tensors into a single tensor."""
     jfcn = RFContext.active().lookup('rf_stack_tensors')

--- a/pyrasterframes/src/main/scala/org/locationtech/rasterframes/py/PyRFContext.scala
+++ b/pyrasterframes/src/main/scala/org/locationtech/rasterframes/py/PyRFContext.scala
@@ -140,6 +140,9 @@ class PyRFContext(implicit sparkSession: SparkSession) extends RasterFunctions
   def rf_explode_tiles_sample(sampleFraction: Double, seed: Long, cols: Column*): Column =
     rf_explode_tiles_sample(sampleFraction, Some(seed), cols: _*)
 
+  def rf_explode_tensor_sample(col: Column, sampleFraction: Double, seed: Long): Column =
+    rf_explode_tensor_sample(col, sampleFraction, Some(seed))
+
   def tileColumns(df: DataFrame): Array[Column] =
     df.asLayer.tileColumns.toArray
 


### PR DESCRIPTION
This PR adds the ability to explode a tensor out into an MLLib `Vector` per pixel. These can be consumed on the python side with `toArray`, which will produce a `numpy array` representation.
This:
```scala
      val exploded = df.select(
        col("tensor_data.tensor_context"),
        rf_explode_tensor_sample(col("tensor_data.tensor"), 0.2)
      )
      exploded.show
```
yields this:
![image](https://user-images.githubusercontent.com/1977405/73864711-1d82a800-4810-11ea-8b2a-eafe52210872.png)



(supersedes #30)